### PR TITLE
fix badges and some on delete set null

### DIFF
--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -172,15 +172,11 @@ CREATE TABLE IF NOT EXISTS `image_themes` (
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci AUTO_INCREMENT=1;
 
 CREATE TABLE IF NOT EXISTS `badges` (
-  `id` MEDIUMINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `id` TINYINT NOT NULL DEFAULT 1,
   `partner_id` SMALLINT UNSIGNED NOT NULL,
-  `name` VARCHAR(15) NULL,
-  `blocked` TINYINT NOT NULL DEFAULT 1,
-  `notes` TEXT NULL,
-  PRIMARY KEY (`id`),
-  INDEX (`partner_id`),
+  PRIMARY KEY (`id`, `partner_id`),
   FOREIGN KEY (`partner_id`) REFERENCES `partners`(`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci AUTO_INCREMENT=1;
+) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `category_apps` (
   `id` MEDIUMINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -221,8 +217,8 @@ CREATE TABLE IF NOT EXISTS `transaction_apps` (
   `date_transaction` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   INDEX (`partner_id`, `store_id`, `app_id`),
-  FOREIGN KEY (`partner_id`) REFERENCES `partners`(`id`) ON DELETE SET NULL,
-  FOREIGN KEY (`app_id`) REFERENCES `apps`(`id`) ON DELETE SET NULL
+  FOREIGN KEY (`partner_id`) REFERENCES `partners`(`id`),
+  FOREIGN KEY (`app_id`) REFERENCES `apps`(`id`)
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci AUTO_INCREMENT=1;
 
 CREATE TABLE IF NOT EXISTS `transaction_themes` (
@@ -236,8 +232,8 @@ CREATE TABLE IF NOT EXISTS `transaction_themes` (
   `date_transaction` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   INDEX (`partner_id`, `store_id`, `theme_id`),
-  FOREIGN KEY (`partner_id`) REFERENCES `partners`(`id`) ON DELETE SET NULL,
-  FOREIGN KEY (`theme_id`) REFERENCES `themes`(`id`) ON DELETE SET NULL
+  FOREIGN KEY (`partner_id`) REFERENCES `partners`(`id`),
+  FOREIGN KEY (`theme_id`) REFERENCES `themes`(`id`)
 ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_unicode_ci AUTO_INCREMENT=1;
 
 CREATE TABLE IF NOT EXISTS `favorites_apps` (
@@ -261,5 +257,5 @@ CREATE TABLE IF NOT EXISTS `historic_withdrawal` (
   `value_withdrawal` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   INDEX (`partner_id`),
-  FOREIGN KEY (`partner_id`) REFERENCES `partners` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  FOREIGN KEY (`partner_id`) REFERENCES `partners` (`id`)
 ) ENGINE=InnoDB CHARACTER SET uft8 COLLATE utf8_unicode_ci AUTO_INCREMENT=1;

--- a/sql/tables.sql
+++ b/sql/tables.sql
@@ -255,6 +255,8 @@ CREATE TABLE IF NOT EXISTS `historic_withdrawal` (
   `partner_id` SMALLINT UNSIGNED NOT NULL,
   `date_withdrawal` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `value_withdrawal` MEDIUMINT UNSIGNED NOT NULL DEFAULT 0,
+  `transaction_code` VARCHAR(255) NULL,
+  `notes` TEXT NULL,
   PRIMARY KEY (`id`),
   INDEX (`partner_id`),
   FOREIGN KEY (`partner_id`) REFERENCES `partners` (`id`)


### PR DESCRIPTION
We don't need auto_increment on badges, we have a limited pre-defined number of badges, we can store that on an PHP array, than use the array element number as ID on MySQL table.
No needed to use 'blocked', if the partner doesn't have unlocked the badge, will not exists the line on table for this partner and badge, if the line exists it means that the partner unlocked the badge.
Replicate the badge name is a bad idea, we can store that on the PHP array.
Why to use notes here?

We can't use  ON DELETE SET NULL for theme_id, app_id and partner_id, because they are NOT NULL.

For financial control, it's not a good idea to delete stored withdrawals, so i've removed  ON DELETE CASCADE ON UPDATE CASCADE.